### PR TITLE
Use env var instead of a hardcoded host name

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,7 +2,7 @@
 service: server
 image: ashleyrudland87/ash
 servers:
-    - 195.201.25.22
+    - <%= ENV["VPS_HOSTNAME"] %>
 registry:
     username:
         - KAMAL_REGISTRY_USERNAME


### PR DESCRIPTION
Allows avoiding exposing the ip to public repo.
In order this to work one needs `VPS_HOSTNAME` env var